### PR TITLE
chore: Use a new artifact id for our patch instead of classifier.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).enablePlugins(VersioningPlugin)
 
-name := "autoschema"
+name := "autoschema-talend"
 
 organization := "com.sauldhernandez"
 
@@ -19,10 +19,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.1.7" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test"
 )
-
-artifact in (Compile, packageBin) ~= { art =>
-  art.copy(`classifier` = Some("talend"))
-}
 
 useGpg := true
 


### PR DESCRIPTION
We are currently using an classifier talend to distinguish between the "real" and our patched version of autoschema. This doesn't play nicely with sbt-coursier.

This PR removes the classifier and assigns a different artifactId autoschema-talend to make this distinction. This change will be reflected in our sbt plugin 0.7.1.